### PR TITLE
in GitIgnore inhalt komplett ausgeschlossen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,5 @@
 Upload.zip
-Latex/inhalt/Anhang.tex
-Latex/inhalt/Einleitung.tex
-Latex/inhalt/Erklärung.tex
-Latex/inhalt/Fazit.tex
-Latex/inhalt/Kapitel2.tex
-Latex/inhalt/Kapitel3.tex
-Latex/inhalt/Kapitel4.tex
-Latex/inhalt/Titelseite_3Autoren.tex
-Latex/inhalt/Titelseite_Praxisbeleg.tex
-Latex/inhalt/Kapitel2.tex
+Latex/inhalt/
 Latex/literatur.bib
 Latex/bilder/
 Latex/main.pdf


### PR DESCRIPTION
Git beschwert sich sonst (wahrscheinlich wegen des Zeitstempels), dass der Ordner geändert wurde.