### PR TITLE
fix typo

### DIFF
--- a/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
+++ b/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
@@ -14,7 +14,7 @@
 \vspace{1.0cm}
 \textbf{Vorgelegt am:}\quad\quad\quad & \abgabedatum\\
 
-\textbf{Von:}           ~ & \textbf{\autor1}\\
+\textbf{Von:}           ~ & \textbf{\autoreins}\\
 
 \textbf{Studiengang:}   ~ & \studiengang \\
 \vspace{1.0cm}


### PR DESCRIPTION
changed "\autor1" to "\autoreins" in Titelseite_Praxisbeleg.tex

@TheColin21 hatte es wahrscheinlich eilig ^^