### PR TITLE
Titelseite Praxisbeleg angepasst, Zukunftssicherheit verbessert

### DIFF
--- a/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
+++ b/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
@@ -15,17 +15,26 @@
 \textbf{Vorgelegt am:}\quad\quad\quad & \abgabedatum\\
 
 \textbf{Von:}           ~ & \textbf{\autoreins}\\
+~ & Am Ende 128 \\
+\vspace{1.0cm}
+~ & 08371 Glauchau \\
 
 \textbf{Studiengang:}   ~ & \studiengang \\
 \vspace{1.0cm}
 \textbf{Studienrichtung:} ~ & \studienrichtung \\
 \vspace{1.0cm}
 \textbf{Seminargruppe:} ~ & \seminargruppe \\
-
+\vspace{1.0cm}
 \textbf{Matrikelnummer:} ~ & \matnumeins \\
+
+\textbf{Praxispartner:} ~ & \institutioneins \\
+~ & Industriestraße 666 \\
+\vspace{1.0cm}
+~ & 5121 Fucking \\
 
 \textbf{Gutachter:}     ~ & \betreuereins \\ ~ & (\institutioneins)\\
                         ~ & \betreuerzwei \\ ~ & (\institutionzwei)\\
+\vspace{1.0cm}
                         
 \end{tabular}}
 \end{flushleft}

--- a/Latex/inhalt_example/metadaten.sty
+++ b/Latex/inhalt_example/metadaten.sty
@@ -1,3 +1,5 @@
+%Die Adressen von Autor und Praxispartner bei einem Praxisbeleg müssen in Titelseite_Praxisbeleg eingetragen werden
+
 %Autor 1:
 \newcommand{\autoreins}{Name 1}
 %Autor 2:
@@ -7,11 +9,11 @@
 %Autoren - für PDF Titel
 \newcommand{\autoren}{Namen, viele Namen}
 %Matrikelnummer 1:
-\newcommand{\matnumeins}{1234567}
+\newcommand{\matnumeins}{4001234}
 %Matrikelnummer 2:
-\newcommand{\matnumzwei}{1234567}
+\newcommand{\matnumzwei}{4001235}
 %Matrikelnummer 3:
-\newcommand{\matnumdrei}{1234567}
+\newcommand{\matnumdrei}{4001236}
 %Titel:
 \newcommand{\titel}{Cooler Titel}
 %Kurzbeschreibung:
@@ -29,6 +31,6 @@
 %Betreuer 2:
 \newcommand{\betreuerzwei}{1 anderer nicer Dude}
 %Institution 1:
-\newcommand{\institutioneins}{1 nice Institution}
+\newcommand{\institutioneins}{FIRMA GmbH \& Co. KG}
 %Institution 2:
-\newcommand{\institutionzwei}{1 andere nice Institution}
+\newcommand{\institutionzwei}{Staatliche Studienakademie Glauchau}

--- a/Latex/vorlage.tex
+++ b/Latex/vorlage.tex
@@ -213,8 +213,8 @@
 %! Kopf- und Fußzeile
 \usepackage[automark]{scrlayer-scrpage} 
 \pagestyle{scrheadings} 
-\clearscrheadings 
-\clearscrplain
+\clearmainofpairofpagestyles 
+\clearplainofpairofpagestyles
 \renewcommand*{\sectionmarkformat}{}
 \rohead{\textnormal{\headmark}}
 \lohead{\includegraphics[height=8mm]{bilder/logo.png}}
@@ -278,8 +278,8 @@
   \newpage
   \pagenumbering{gobble}
   \pagestyle{scrheadings} 
-  \clearscrheadings 
-  \clearscrplain 
+  \clearmainofpairofpagestyles 
+  \clearplainofpairofpagestyles
   \rohead{\textnormal{Anhang~\arabic{section}}}
   \lohead{\textnormal{\currentname}}
   \lofoot{} 

--- a/Latex/vorlage.tex
+++ b/Latex/vorlage.tex
@@ -73,6 +73,7 @@
 \usepackage{graphicx}
 \usepackage{float}
 \usepackage[a4paper,lmargin={2.5cm},rmargin={2.5cm},tmargin={2cm},bmargin={2cm}]{geometry}
+\usepackage{lineno}
 \usepackage{csquotes}
 
 %! Code Integration im Dokument


### PR DESCRIPTION
Felder für Adresse von Autor und Praxispartner in Titelseite eingefügt, Hinweis in metadaten.sty eingefügt, veraltete Befehle \clearscrheadings und \clearscrplain durch aktuelle Äquivalente ersetzt, Paket lineno (wurde vorher scheinbar eh implizit geladen) explizit vor csquotes laden um Warnung zu verhindern