### PR TITLE
Titelseiten, Erklärungen, README gefixt

### DIFF
--- a/Latex/inhalt_example/Erklärung_3Autoren.tex
+++ b/Latex/inhalt_example/Erklärung_3Autoren.tex
@@ -25,16 +25,11 @@ Wir erklären hiermit ehrenwörtlich,
 \end{enumerate}
 Wir sind uns bewusst, dass eine falsche Erklärung rechtliche Folgen haben wird.\\[1,5cm]
 		
-\vspace*{20mm}
-
-\absatz
-Glauchau, \abgabedatum
-\par\noindent\rule{0.35\columnwidth}{0.4pt}\hspace{0.05\columnwidth}\rule{0.6\columnwidth}{0.4pt}\\
-Ort, Datum\hspace{0.27\columnwidth}Unterschriften
-
 \vfill
 
-\absatz
+Glauchau, \abgabedatum\newline\noindent\rule{0.35\columnwidth}{0.4pt}\hspace{0.05\columnwidth}\rule{0.6\columnwidth}{0.4pt}\\
+Ort, Datum\hspace{0.27\columnwidth}Unterschriften
+
 {\footnotesize Dies ist eine zur Nutzung mit mehreren Autoren und \LaTeX\ angepasste Version der in \href{https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_Hinweise_zur_Anfertigung_wissenschaftlicher_Arbeiten.pdf}{Anhang 4 der Hinweise zur Anfertigung wissenschaftlicher Arbeiten an der Staatlichen Studienakademie Glauchau vorgegebenen ehrenwörtlichen Erklärung.}}
 
 
@@ -45,9 +40,9 @@ Ort, Datum\hspace{0.27\columnwidth}Unterschriften
 
 \begin{minipage}{0.5\columnwidth}
 \includesvg[width=\columnwidth]{bilder/ba_glauchau_logo.svg}
-%alternativ mit PNG Logo für Menschen, die zu faul sich Inkscape zu installieren,
-%was deutlich weniger hübsch im Druck aussehen dürfte
-%\includegraphics[width=\columnwidth]{bilder/ba-gc-logo.svg}
+%alternativ mit PNG Logo, falls Inkscape nicht installiert werden, bzw. nicht der PATH-Variable hinzugefügt werden soll
+%MERKE: die SVG-Version sieht im Druck deutlich besser aus
+%\includegraphics[width=\columnwidth]{bilder/ba-gc-logo.png}
 \end{minipage}
 \begin{minipage}{0.45\columnwidth}
 \begin{flushright}
@@ -58,13 +53,10 @@ Ort, Datum\hspace{0.27\columnwidth}Unterschriften
 
 \begin{center}\textbf{\huge{Erklärung zur Prüfung wissenschaftlicher Arbeiten}}\end{center}
 
-\absatz
 Die Bewertung wissenschaftlicher Arbeiten erfordert die Prüfung auf Plagiate. Die hierzu von der Staatlichen Studienakademie Glauchau eingesetzte Prüfungskommission nutzt sowohl eigene Software als auch diesbezügliche Leistungen von Drittanbietern. Dies erfolgt gemäß \href{https://www.revosax.sachsen.de/vorschrift/1672-Saechsisches-Datenschutzgesetz#p7}{§ 7 des Gesetzes zum Schutz der informationellen Selbstbestimmung im Freistaat Sachsen (Sächsisches Datenschutzgesetz - SächsDSG)} vom 25. August 2003 (Rechtsbereinigt mit Stand vom 31. Juli 2011) im Sinne einer Datenverarbeitung im Auftrag.
 
-\absatz
 Die Studierenden bevollmächtigen die Mitglieder der Prüfungskommission hiermit zur Inanspruchnahme o. g. Dienste. In begründeten Ausnahmefällen kann der Datenschutzbeauftragte der Berufsakademie Sachsen sowohl von den Verfassern der wissenschaftlichen Arbeit als auch von der Prüfungskommission in den Entscheidungsprozess einbezogen werden.
 
-\absatz
 \arrayrulewidth=0.5pt
 
 \begin{table}[H]
@@ -91,5 +83,4 @@ Unterschriften: & & & \\
 
 \vfill
 
-\absatz
 {\footnotesize Dies ist eine zur Nutzung mit mehreren Autoren und \LaTeX\ angepasste Version der in \href{https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_Hinweise_zur_Anfertigung_wissenschaftlicher_Arbeiten.pdf}{Anhang 6 der Hinweise zur Anfertigung wissenschaftlicher Arbeiten an der Staatlichen Studienakademie Glauchau vorgegebenen Zustimmung zur Plagiatsprüfung.}}

--- a/Latex/inhalt_example/Erklärung_Praxisbeleg.tex
+++ b/Latex/inhalt_example/Erklärung_Praxisbeleg.tex
@@ -25,13 +25,10 @@ Ich erkläre hiermit ehrenwörtlich,
 \end{enumerate}
 Ich bin mir bewusst, dass eine falsche Erklärung rechtliche Folgen haben wird.\\[1,5cm]
 			
-\vspace*{20mm}
-
-Glauchau, \abgabedatum
-\par\noindent\rule{0.35\columnwidth}{0.4pt}\hspace{0.05\columnwidth}\rule{0.6\columnwidth}{0.4pt}\\
-Ort, Datum\hspace{0.27\columnwidth}Unterschrift
-
 \vfill
+
+Glauchau, \abgabedatum \newline\noindent\rule{0.35\columnwidth}{0.4pt}\hspace{0.05\columnwidth}\rule{0.6\columnwidth}{0.4pt}\\
+Ort, Datum\hspace{0.27\columnwidth}Unterschrift
 
 {\footnotesize Dies ist eine zur Nutzung mit \LaTeX\ angepasste Version der in \href{https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_Hinweise_zur_Anfertigung_wissenschaftlicher_Arbeiten.pdf}{Anhang 4 der Hinweise zur Anfertigung wissenschaftlicher Arbeiten an der Staatlichen Studienakademie Glauchau vorgegebenen ehrenwörtlichen Erklärung.}}
 
@@ -42,9 +39,9 @@ Ort, Datum\hspace{0.27\columnwidth}Unterschrift
 
 \begin{minipage}{0.5\columnwidth}
 \includesvg[width=\columnwidth]{bilder/ba_glauchau_logo.svg}
-%alternativ mit PNG Logo für Menschen, die zu faul sich Inkscape zu installieren,
-%was deutlich weniger hübsch im Druck aussehen dürfte
-%\includegraphics[width=\columnwidth]{bilder/ba-gc-logo.svg}
+%alternativ mit PNG Logo, falls Inkscape nicht installiert werden, bzw. nicht der PATH-Variable hinzugefügt werden soll
+%MERKE: die SVG-Version sieht im Druck deutlich besser aus
+%\includegraphics[width=\columnwidth]{bilder/ba-gc-logo.png}
 \end{minipage}
 \begin{minipage}{0.45\columnwidth}
 \begin{flushright}

--- a/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
+++ b/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
@@ -1,41 +1,32 @@
 %Titelseite
-
 \begin{titlepage}
 \begin{center}
-
-\textbf{\Huge Praxisbeleg}\\
-\vspace{1.5cm}
+\textbf{\Huge \begin{center} Praxisbeleg \end{center}}
 \LARGE{\titel \\}
-\vspace{1.5cm}
+\vspace{1.0cm}
 \end{center}
 \begin{flushleft}
 \large{
 \begin{tabular}{l l r}
-\vspace{1.0cm}
 \textbf{Vorgelegt am:}\quad\quad\quad & \abgabedatum\\
-
 \textbf{Von:}           ~ & \textbf{\autoreins}\\
 ~ & Am Ende 128 \\
-\vspace{1.0cm}
+\vspace{0.7cm}
 ~ & 08371 Glauchau \\
-
 \textbf{Studiengang:}   ~ & \studiengang \\
-\vspace{1.0cm}
+\vspace{0.7cm}
 \textbf{Studienrichtung:} ~ & \studienrichtung \\
-\vspace{1.0cm}
+\vspace{0.7cm}
 \textbf{Seminargruppe:} ~ & \seminargruppe \\
-\vspace{1.0cm}
+\vspace{0.7cm}
 \textbf{Matrikelnummer:} ~ & \matnumeins \\
-
 \textbf{Praxispartner:} ~ & \institutioneins \\
 ~ & Industriestraße 666 \\
-\vspace{1.0cm}
+\vspace{0.7cm}
 ~ & 5121 Fucking \\
-
 \textbf{Gutachter:}     ~ & \betreuereins \\ ~ & (\institutioneins)\\
                         ~ & \betreuerzwei \\ ~ & (\institutionzwei)\\
-\vspace{1.0cm}
-                        
+\vspace{0.7cm}
 \end{tabular}}
 \end{flushleft}
 \end{titlepage}

--- a/Latex/vorlage.tex
+++ b/Latex/vorlage.tex
@@ -63,6 +63,7 @@
 \usepackage{amssymb}
 \usepackage{amsthm}
 \usepackage{tabularx}
+\usepackage{multirow}
 \usepackage{setspace} 
 \usepackage{booktabs}
 \usepackage{svg}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ Unterhaltung und Besprechung:
 
 [https://chat.4de19.de/channel/latex](https://chat.4de19.de/channel/latex)
 
-## Changes 22. November 2020
+
+## Changes 05. Januar 2021
+
+- Titelseiten und Erklärungen an neue Changes und lange Titel angepasst
+
+- Multirow Paket eingefügt
+
+- Kommentare zu SVGs angepasst
 
 - Bild Command benötigt jetzt noch einen weiteren Parameter, den labelnamen
 


### PR DESCRIPTION
Titelseiten und Erklärungen sollten bei langen Überschriften keine Probleme mehr machen, README aktualisiert und Datum korrigiert