### PR TITLE
Abstand Titelseite + #46 fix

### DIFF
--- a/Latex/inhalt_example/Anhang.tex
+++ b/Latex/inhalt_example/Anhang.tex
@@ -35,7 +35,7 @@
 %! Anhang 1
 \section{Erster toller Anhang}
 Hihi hier kommt eigentlich ein Anhangverzeichnis hin :D
-\newpage
+\clearpage
 
 %! Anhang 2
 \section{Inhalt der CD}
@@ -45,7 +45,7 @@ CD mit folgenden Inhalten:
 	\item Latex Dateien
 	\item Youtube-Video als Bonus
 \end{itemize}
- \newpage
+ \clearpage
 
 %! Eidestattliche Erklärung, hier zwischen Version für einen oder mehrere Autoren umschalten
 \input{inhalt/Erklärung_Praxisbeleg}

--- a/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
+++ b/Latex/inhalt_example/Titelseite_Praxisbeleg.tex
@@ -8,6 +8,7 @@
 \begin{flushleft}
 \large{
 \begin{tabular}{l l r}
+\vspace{0.7cm}
 \textbf{Vorgelegt am:}\quad\quad\quad & \abgabedatum\\
 \textbf{Von:}           ~ & \textbf{\autoreins}\\
 ~ & Am Ende 128 \\


### PR DESCRIPTION
Abstand zwischen "Vorgelegt am" und "Von" auf 1-Autor Titelseite wiederhergestellt, \newpage in Anhang.tex durch \clearpage ersetzt, fixes #46 (zumindest laut @jemand771 