### PR TITLE
PDF-Builds per GitHub actions

### DIFF
--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -1,0 +1,21 @@
+name: Document builder
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pull latest image
+        run: docker pull jemand771/latex-build
+      - name: Build PDF
+        run: docker run --rm -v "$GITHUB_WORKSPACE/Latex:/latex" -u $(id -u ${USER}):$(id -g ${USER}) jemand771/latex-build
+      - name: Archive PDF
+        uses: actions/upload-artifact@v2
+        with:
+          name: main.pdf
+          path: Latex/main.pdf


### PR DESCRIPTION
hat bisschen gedauert, aber hier ist es! Bei jedem push oder PR wird eine pdf gebaut und archiviert. In diesem repo hilft uns das, syntaktische Fehler in Vorlage und Beispieldateien zu finden.

Der eigentliche Sinn der sache: In forks bzw. Beleg-Repos mit diesem hier als upstream existiert dann immer eine main.pdf auf dem gleichen Stand wie der aktuelle Code. Das soll Konsistenz schaffen, ersetzt aber _nicht_ die lokalen Builds via docker/LaTeX workshop/TeXMaker/...

related: #47, da fehlt allerdings noch wiki-zeugs