### PR TITLE
VSCode-extensions aus .gitpod.yml empfehlen

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,7 @@ tasks:
     command: docker pull jemand771/latex-build && exit
 
 vscode:
+# remember to update these together with .vscode/extensions.json
   extensions:
 # as of now, gitpod only runs vscode 1.56, however, statusbar-commands 1.7.0 requires vscode 1.57
 # gitpod doesn't pick the right version on its own so we have to hardcode it

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    // remember to update these together with .gitpod.yml
+    "recommendations": [
+        "anweber.statusbar-commands",
+        "aaron-bond.better-comments",
+        "CoenraadS.bracket-pair-colorizer",
+        "James-Yu.latex-workshop"
+    ]
+}


### PR DESCRIPTION
Helfen bei der einrichtung ausserhalb von gitpod, wo extensions nicht automatisch instaliert werden können

wenn ihr noch mehr extensions-wünsche habt wäre hier die gelegenheit die mit reinzumogeln ^^

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/64"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

