### PR TITLE
Build-Container versionieren

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,8 +2,9 @@
 tasks:
 # even though will be updated by starting the default build task in in tasks.json for docker >=20 (--pull always),
 # having the image inside the workspace already saves time when building for the first time in a new gitpod
-  - prebuild: docker pull jemand771/latex-build && exit
-    command: docker pull jemand771/latex-build && exit
+# note: pulling all tags is kind of wasteful, but there's no (easy) way to only pull the tag we actually need
+  - prebuild: docker pull -a jemand771/latex-build && exit
+    command: docker pull -a jemand771/latex-build && exit
 
 vscode:
 # remember to update these together with .vscode/extensions.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,5 +59,6 @@
                 "Delete temporary files"
             ]
         },
-    ]
+    ],
+    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.0.0"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build LaTeX using Docker",
             "type": "shell",
-            "command": "docker pull jemand771/latex-build && docker run -u $(id -u ${USER}):$(id -g ${USER}) --rm -v \"${workspaceFolder}/Latex:/latex\" jemand771/latex-build",
+            "command": "docker pull ${config:vorlage-latex.buildcontainer} && docker run -u $(id -u ${USER}):$(id -g ${USER}) --rm -v \"${workspaceFolder}/Latex:/latex\" ${config:vorlage-latex.buildcontainer}",
             "problemMatcher": [
                 {
                     "owner": "latex",
@@ -39,7 +39,7 @@
             ],
             "group": "build",
             "windows": {
-                "command": "docker run --pull always --rm -v \"${workspaceFolder}/Latex:/latex\" jemand771/latex-build"
+                "command": "docker run --pull always --rm -v \"${workspaceFolder}/Latex:/latex\" ${config:vorlage-latex.buildcontainer}"
             }
         },
         {


### PR DESCRIPTION
Das bringt eher für die Zukuft was, als für jetzt: wenn man nach viele Änderungen an Vorlage+Container wieder zurück zu einem alten Stand will, gibt es bisher keine möglichkeit, einen alten container zu bekommen (ausser das image selbst zu bauen)

Ab dieser PR wird der build-container über seine version festgelegt, statt einfach immer den neuesten zu verwenden

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/67"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

