### PR TITLE
bump buildcontainer v1.0.0 -> v1.1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,5 @@
             ]
         },
     ],
-    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.0.0"
+    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.1.0"
 }


### PR DESCRIPTION
neu in dieser version: pythontex support
brauchen wir gerade noch nicht, das benutz' ich aber für die dynamischen metadaten -> früher oder später muss das sowieso rein ^^

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/68"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

