### PR TITLE
synctex support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-Latex/main.pdf
-Latex/svg-inkscape
-.build
-
 ### LaTeX ###
 ## Core latex/pdflatex auxiliary files:
 *.aux
@@ -298,8 +294,17 @@ TSWLatexianTemp*
 *.glstex
 
 # End of https://www.toptal.com/developers/gitignore/api/latex
+
+# jetbrains IDE files
 /.idea/.gitignore
 /.idea/misc.xml
 /.idea/modules.xml
 /.idea/vcs.xml
 /.idea/Vorlage-Latex.iml
+
+# excluding build artifacts from vcs is good practice
+/Latex/main.pdf
+
+# temporary build files
+/Latex/svg-inkscape/
+/Latex/.build/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,5 @@
             ]
         }
     ],
-    "vorlage-latex.buildcontainer": "jemand771/latex-build:experimental"
+    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.2.0"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,5 @@
             ]
         },
     ],
-    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.1.0"
+    "vorlage-latex.buildcontainer": "jemand771/latex-build:experimental"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build LaTeX using Docker",
             "type": "shell",
-            "command": "docker pull ${config:vorlage-latex.buildcontainer} && docker run -u $(id -u ${USER}):$(id -g ${USER}) --rm -v \"${workspaceFolder}/Latex:/latex\" ${config:vorlage-latex.buildcontainer}",
+            "command": "docker pull ${config:vorlage-latex.buildcontainer} && docker run -u $(id -u ${USER}):$(id -g ${USER}) --rm -v \"${workspaceFolder}/Latex:/latex\" -e HOST_PATH=\"${workspaceFolder}/Latex\" ${config:vorlage-latex.buildcontainer}",
             "problemMatcher": [
                 {
                     "owner": "latex",
@@ -39,7 +39,7 @@
             ],
             "group": "build",
             "windows": {
-                "command": "docker run --pull always --rm -v \"${workspaceFolder}/Latex:/latex\" ${config:vorlage-latex.buildcontainer}"
+                "command": "docker run --pull always --rm -v \"${workspaceFolder}/Latex:/latex\" -e HOST_PATH=\"${workspaceFolder}/Latex\" ${config:vorlage-latex.buildcontainer}"
             }
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,7 +39,7 @@
             ],
             "group": "build",
             "windows": {
-                "command": "docker run --pull always --rm -v \"${workspaceFolder}/Latex:/latex\" -e HOST_PATH=\"${workspaceFolder}/Latex\" ${config:vorlage-latex.buildcontainer}"
+                "command": "docker run --pull always --rm -v \\\"${workspaceFolder}/Latex:/latex\\\" -e HOST_PATH=\\\"${workspaceFolder}/Latex\\\" ${config:vorlage-latex.buildcontainer}"
             }
         },
         {


### PR DESCRIPTION
siehe rocketchat und #59 und https://github.com/jemand771/latex-build/issues/5 für mehr infos
kurzversion: synctex geht bis auf forward unter windows, und das wird in der nächsten latex workshop version gefixed

nicht mergen, das docker-image steht noch auf `experimental` bis ich da ne neue version raus hab ^^

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/73"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

