### PR TITLE
bump container -> v1.2.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,5 @@
             ]
         }
     ],
-    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.2.0"
+    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.2.1"
 }


### PR DESCRIPTION
fix für \inputminted+autogobble

closes #70 

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/74"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

