### PR TITLE
gitpod: prebuild -> init (2)

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,9 +2,7 @@
 tasks:
 # even though will be updated by starting the default build task in in tasks.json for docker >=20 (--pull always),
 # having the image inside the workspace already saves time when building for the first time in a new gitpod
-# note: pulling all tags is kind of wasteful, but there's no (easy) way to only pull the tag we actually need
-  - prebuild: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])") && exit
-    command: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])") && exit
+  - init: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])")
 
 vscode:
 # remember to update these together with .vscode/extensions.json

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,8 @@
 tasks:
 # even though will be updated by starting the default build task in in tasks.json for docker >=20 (--pull always),
 # having the image inside the workspace already saves time when building for the first time in a new gitpod
-  - init: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])") && exit
+  - init: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])")
+    command: exit
 
 vscode:
 # remember to update these together with .vscode/extensions.json

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@
 tasks:
 # even though will be updated by starting the default build task in in tasks.json for docker >=20 (--pull always),
 # having the image inside the workspace already saves time when building for the first time in a new gitpod
-  - init: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])")
+  - init: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])") && exit
 
 vscode:
 # remember to update these together with .vscode/extensions.json


### PR DESCRIPTION
der task-typ prebuild wird deprecated, stattdessen soll init benutzt werden. weil init auch beim workspace-start ausgeführt wird, fällt der command task gleich mit weg. hätte man eigentlich auch eher drauf kommen können

die PR ist identisch zu #75 aber ich wollte den workspace prebuild nochmal triggern :D

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/76"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

