### PR TITLE
Hotfix Windows Clean

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,7 +47,7 @@
             "type": "shell",
             "command": "rm -rf \"${workspaceFolder}/Latex/.build\"",
             "windows": {
-                "command": "del /F /S /Q -\"${workspaceFolder}\\Latex\\.build\""
+                "command": "Remove-Item -Force -Recurse \"${workspaceFolder}\\Latex\\.build\""
             },
             "presentation": {
                 "reveal": "never"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,7 +47,9 @@
             "type": "shell",
             "command": "rm -rf \"${workspaceFolder}/Latex/.build\"",
             "windows": {
-                "command": "Remove-Item -Force -Recurse \"${workspaceFolder}\\Latex\\.build\""
+                "type": "process",
+                "command": "powershell.exe",
+                "args": ["Remove-Item -Force -Recurse \"${workspaceFolder}\\Latex\\.build\""]
             },
             "presentation": {
                 "reveal": "never"


### PR DESCRIPTION
die Windows Befehle werden auf powershell ausgeführt, diese nutzt del nur als alias zu "Remove-Item"

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/77"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

