### PR TITLE
bump buildcontainer -> v1.5.0 und diff-pdf

### DIFF
--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -15,9 +15,65 @@ jobs:
       - name: Pull container image
         run: docker pull $DOCKER_IMAGE
       - name: Build PDF
-        run: docker run --rm -v "$GITHUB_WORKSPACE/Latex:/latex" -u $(id -u ${USER}):$(id -g ${USER}) $DOCKER_IMAGE
+        run: docker run --rm -v "$GITHUB_WORKSPACE/Latex:/latex" -u $(id -u ${USER}):$(id -g ${USER}) -e DISABLE_DIFFPDF=1 -e DISABLE_SYNCTEX=1 $DOCKER_IMAGE
       - name: Archive PDF
         uses: actions/upload-artifact@v2
         with:
           name: main.pdf
           path: Latex/main.pdf
+  diff-pdf:
+    # only runs if pdf build was successful
+    needs: build-pdf
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout commit before push
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.before }}
+      - name: Checkout pull request base
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Determine container version
+        run: echo DOCKER_IMAGE=$(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])") >> $GITHUB_ENV
+      - name: Pull container image
+        run: docker pull $DOCKER_IMAGE
+      - name: Build PDF
+        id: build-prev
+        # NOTE there currently is no better way to mark a job as "allow failure" so we have to use this little hack.
+        # the job will still appear as successful even if the diff build fails which might be slightly misleading
+        run: |
+          if docker run --rm -v "$GITHUB_WORKSPACE/Latex:/latex" -u $(id -u ${USER}):$(id -g ${USER}) -e DISABLE_DIFFPDF=1 -e DISABLE_SYNCTEX=1 $DOCKER_IMAGE; then
+            echo "::set-output name=status::okay"
+          else
+            echo "::set-output name=status::fail"
+            echo "::warning::previous build failed, not generating diff"
+          fi
+      - name: Download new main.pdf
+        if: ${{ steps.build-prev.outputs.status == 'okay' }}
+        uses: actions/download-artifact@v2
+        with:
+          name: main.pdf
+      - name: Generate diff
+        if: ${{ steps.build-prev.outputs.status == 'okay' }}
+        id: diff
+        run: |
+          if docker run --rm -v "$GITHUB_WORKSPACE:/data" --init -u $(id -u ${USER}):$(id -g ${USER}) $DOCKER_IMAGE xvfb-run diff-pdf -v -m -s --output-diff="/data/main-diff.pdf" "/data/Latex/main.pdf" "/data/main.pdf"; then
+            echo "::set-output name=identical::true"
+            echo "::warning::diff-pdf: no change detected"
+          else
+            echo "::set-output name=identical::false"
+          fi
+      - name: Archive diff PDF
+        if: |
+          steps.build-prev.outputs.status == 'okay'
+          && steps.diff.outputs.identical == 'false'
+        uses: actions/upload-artifact@v2
+        with:
+          name: main-diff.pdf
+          path: main-diff.pdf

--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           name: main.pdf
           path: Latex/main.pdf
-  diff-pdf:
+  diff:
     # only runs if pdf build was successful
     needs: build-pdf
     if: |

--- a/.gitignore
+++ b/.gitignore
@@ -304,6 +304,7 @@ TSWLatexianTemp*
 
 # excluding build artifacts from vcs is good practice
 /Latex/main.pdf
+/Latex/main-diff.pdf
 
 # temporary build files
 /Latex/svg-inkscape/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,5 @@
             ]
         }
     ],
-    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.2.1"
+    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.5.0"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,5 @@
             ]
         }
     ],
-    "vorlage-latex.buildcontainer": "jemand771/latex-build:v1.5.0"
+    "vorlage-latex.buildcontainer": "ghcr.io/jemand771/latex-build:v1.5.0"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,8 @@
         {
             "label": "Build LaTeX using Docker",
             "type": "shell",
-            "command": "docker pull ${config:vorlage-latex.buildcontainer} && docker run -u $(id -u ${USER}):$(id -g ${USER}) --init --rm -v \"${workspaceFolder}/Latex:/latex\" -e HOST_PATH=\"${workspaceFolder}/Latex\" -e DISABLE_DIFFPDF=1 ${config:vorlage-latex.buildcontainer}",
+            # Remove '-e DISABLE_DIFFPDF=1' to enable the differential PDF generation.
+            "command": "docker run -u $(id -u ${USER}):$(id -g ${USER}) --init --rm -v \"${workspaceFolder}/Latex:/latex\" -e HOST_PATH=\"${workspaceFolder}/Latex\" -e DISABLE_DIFFPDF=1 ${config:vorlage-latex.buildcontainer}",
             "problemMatcher": [
                 {
                     "owner": "latex",
@@ -39,7 +40,8 @@
             ],
             "group": "build",
             "windows": {
-                "command": "docker run --pull always --init --rm -v \\\"${workspaceFolder}/Latex:/latex\\\" -e HOST_PATH=\\\"${workspaceFolder}/Latex\\\" -e DISABLE_DIFFPDF=1 ${config:vorlage-latex.buildcontainer}"
+                # Remove '-e DISABLE_DIFFPDF=1' to enable the differential PDF generation.
+                "command": "docker run --init --rm -v \\\"${workspaceFolder}/Latex:/latex\\\" -e HOST_PATH=\\\"${workspaceFolder}/Latex\\\" -e DISABLE_DIFFPDF=1 ${config:vorlage-latex.buildcontainer}"
             }
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build LaTeX using Docker",
             "type": "shell",
-            "command": "docker pull ${config:vorlage-latex.buildcontainer} && docker run -u $(id -u ${USER}):$(id -g ${USER}) --rm -v \"${workspaceFolder}/Latex:/latex\" -e HOST_PATH=\"${workspaceFolder}/Latex\" ${config:vorlage-latex.buildcontainer}",
+            "command": "docker pull ${config:vorlage-latex.buildcontainer} && docker run -u $(id -u ${USER}):$(id -g ${USER}) --init --rm -v \"${workspaceFolder}/Latex:/latex\" -e HOST_PATH=\"${workspaceFolder}/Latex\" -e DISABLE_DIFFPDF=1 ${config:vorlage-latex.buildcontainer}",
             "problemMatcher": [
                 {
                     "owner": "latex",
@@ -39,7 +39,7 @@
             ],
             "group": "build",
             "windows": {
-                "command": "docker run --pull always --rm -v \\\"${workspaceFolder}/Latex:/latex\\\" -e HOST_PATH=\\\"${workspaceFolder}/Latex\\\" ${config:vorlage-latex.buildcontainer}"
+                "command": "docker run --pull always --init --rm -v \\\"${workspaceFolder}/Latex:/latex\\\" -e HOST_PATH=\\\"${workspaceFolder}/Latex\\\" -e DISABLE_DIFFPDF=1 ${config:vorlage-latex.buildcontainer}"
             }
         },
         {


### PR DESCRIPTION
* support für diff-pdf
* diff-pdf ist aus performancegründen standardmässig deaktiviert

hinweis: das `--init` braucht man für diff-pdf, und weil man das leicht vergisst hab ich's mal als default mit rein genommen. das ändert potenziell das handling von signalen (SIGTERM etc.) an den prozess, was uns aber egal sein kann (abgebrochene builds nützen einem sowieso nichts)

@TheColin21 teste mal unter windows wenn du kannst ^^

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/78"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

