### PR TITLE
Synctex Fix und in Hinweise aufgenommen

### DIFF
--- a/.vscode/keybindings.json
+++ b/.vscode/keybindings.json
@@ -1,0 +1,12 @@
+[
+    {
+        "key": "ctrl+alt+j",
+        "command": "latex-workshop.synctex",
+        "when": "editorTextFocus && editorLangId == 'latex'"
+    },
+    {
+        "key": "ctrl+alt+j",
+        "command": "-latex-workshop.synctex",
+        "when": "editorTextFocus && !config.latex-workshop.bind.altKeymap.enabled && editorLangId == 'latex'"
+    }
+]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "latex-workshop.view.pdf.viewer": "tab",
+    "workbench.editorAssociations": {
+        "*.pdf": "latex-workshop-pdf-hook"
+    },
     "latex-workshop.latex.tools": [
         {
             "name": "warning",

--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -51,4 +51,4 @@ $Q=\text{was noch viel tolleres}$
 
 - Reverse SyncTeX: Um aus der PDF-Ansicht an die entsprechende Stelle im Code zu gelangen, diese mit gehaltener STRG-Taste anklicken.
 
-- Um aus dem Code an die entsprechende Stelle der PDF zu gelangen, STRG+ALT+J drücken.
+- Forward SyncTeX: Um aus dem Code an die entsprechende Stelle der PDF zu gelangen, STRG+ALT+J drücken.

--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -48,3 +48,7 @@ $Q=\text{was noch viel tolleres}$
 - Die einzelnen Zeilen der Formel werden im Mathemathikmodus geschrieben. Die Erklärung der Formelzeichen auch. Siehe dazu auch das HAWA-Dokument.
 
 - Normale Anführungszeichen ("") entsprechen nicht der Deutschen Rechtschreibung. Hierzu das Kommando `\striche{Text}` verwenden.
+
+- Um aus der PDF-Ansicht an die entsprechende Stelle im Code zu gelangen, diese mit gehaltener STRG-Taste anklicken.
+
+- Um aus dem Code an die entsprechende Stelle der PDF zu gelangen, STRG+ALT+J drücken.

--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -49,6 +49,6 @@ $Q=\text{was noch viel tolleres}$
 
 - Normale Anführungszeichen ("") entsprechen nicht der Deutschen Rechtschreibung. Hierzu das Kommando `\striche{Text}` verwenden.
 
-- Um aus der PDF-Ansicht an die entsprechende Stelle im Code zu gelangen, diese mit gehaltener STRG-Taste anklicken.
+- Reverse SyncTeX: Um aus der PDF-Ansicht an die entsprechende Stelle im Code zu gelangen, diese mit gehaltener STRG-Taste anklicken.
 
 - Um aus dem Code an die entsprechende Stelle der PDF zu gelangen, STRG+ALT+J drücken.


### PR DESCRIPTION
Beinhaltet bereits STRG+ALT+J was zum Zeitpunkt dieses commits noch nicht funktioniert. Sollte in nächstem Commit gefixt werden.

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/86"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

