### PR TITLE
bump buildcontainer -> v1.5.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,5 @@
             ]
         }
     ],
-    "vorlage-latex.buildcontainer": "ghcr.io/jemand771/latex-build:v1.5.0"
+    "vorlage-latex.buildcontainer": "ghcr.io/jemand771/latex-build:v1.5.1"
 }


### PR DESCRIPTION
verboserer diff-pdf output im container (analog zu gha)

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/87"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

