### PR TITLE
nginx für externe pdf previews in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,7 @@ tasks:
 # having the image inside the workspace already saves time when building for the first time in a new gitpod
   - init: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])")
     command: exit
+  - command: docker run -d --restart=always -v "$GITPOD_REPO_ROOT/Latex:/usr/share/nginx/html:ro" -p 12345:80 nginx
 
 vscode:
 # remember to update these together with .vscode/extensions.json

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ tasks:
 # having the image inside the workspace already saves time when building for the first time in a new gitpod
   - init: docker pull $(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])")
     command: exit
-  - command: docker run -d --restart=always -v "$GITPOD_REPO_ROOT/Latex:/usr/share/nginx/html:ro" -p 12345:80 nginx
+  - command: docker run -d --name ngix-pdf --restart=always -v "$GITPOD_REPO_ROOT/Latex:/usr/share/nginx/html:ro" -p 12345:80 nginx
 
 vscode:
 # remember to update these together with .vscode/extensions.json


### PR DESCRIPTION
note: das ist kein sicherheitsrisiko-weil der port standardmässig auf private steht. der port ist erst von aussen benutzbar, wenn man ihn in gitpod manuell auf public schaltet

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/94"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

