### PR TITLE
gitpod latex-workshop downgrade

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,9 @@ vscode:
     - anweber.statusbar-commands@1.6.0
     - aaron-bond.better-comments
     - CoenraadS.bracket-pair-colorizer
-    - James-Yu.latex-workshop
+# latex workshop 8.20.2 on openvsx (released on august 24th) has a weird bug where the enter key stops working
+# https://github.com/James-Yu/LaTeX-Workshop/issues/2845
+    - James-Yu.latex-workshop@8.19.2
 
 github:
   prebuilds:


### PR DESCRIPTION
temporärer workaround für das enter-problem auf 8.20.2

note: synctex geht dadurch nicht kaputt, weil nur auf windows >=8.20.x gebraucht wird.
je nachdem, wie lange sich https://github.com/James-Yu/LaTeX-Workshop/issues/2845 zieht reverten wir das sicher bald wieder

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/95"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

