### PR TITLE
Veraltete Extension durch VS Code natives Setting ersetzt

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "recommendations": [
         "anweber.statusbar-commands",
         "aaron-bond.better-comments",
-        "CoenraadS.bracket-pair-colorizer",
         "James-Yu.latex-workshop"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,5 +63,6 @@
             ]
         }
     ],
-    "vorlage-latex.buildcontainer": "ghcr.io/jemand771/latex-build:v1.5.1"
+    "vorlage-latex.buildcontainer": "ghcr.io/jemand771/latex-build:v1.5.1",
+    "editor.bracketPairColorization.enabled": true
 }


### PR DESCRIPTION
Wir haben vorher die Erweiterungen "Bracket Pair Colorizer" empfohlen.
Diese wurde seit ca. 3 Jahren nicht aktualisiert und hat nicht mehr fehlerfrei funktioniert. Es gab zwar eine zweite Version, aber auch die ist unmaintained.

VS Code bietet seit Version 1.60 selbst diese [Funktion](https://code.visualstudio.com/updates/v1_60#_high-performance-bracket-pair-colorization)

Und das beste: das ganze funktioniert korrekt.

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/116"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

