### PR TITLE
Gitpod: bump latex workshop

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,9 +12,7 @@ vscode:
     - anweber.statusbar-commands
     - aaron-bond.better-comments
     - CoenraadS.bracket-pair-colorizer
-# latex workshop 8.20.2 on openvsx (released on august 24th) has a weird bug where the enter key stops working
-# https://github.com/James-Yu/LaTeX-Workshop/issues/2845
-    - James-Yu.latex-workshop@8.19.2
+    - James-Yu.latex-workshop
 
 github:
   prebuilds:


### PR DESCRIPTION
neuste version wieder freigeben, statt auf 8.19.2 zu hardcoden - das problem wurde upstream behoben und die kaputte version wird durch den nächsten release verdrängt

closes #112

erst mergen, wenn https://github.com/James-Yu/LaTeX-Workshop/releases bzw. https://open-vsx.org/extension/James-Yu/latex-workshop ein neues release hat ODER https://github.com/EclipseFdn/open-vsx.org/issues/676 durch ist

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

