### PR TITLE
bracket pair colorizer aus gitpod entfernen

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,6 @@ vscode:
   extensions:
     - anweber.statusbar-commands
     - aaron-bond.better-comments
-    - CoenraadS.bracket-pair-colorizer
 # latex workshop 8.20.2 on openvsx (released on august 24th) has a weird bug where the enter key stops working
 # https://github.com/James-Yu/LaTeX-Workshop/issues/2845
     - James-Yu.latex-workshop@8.19.2


### PR DESCRIPTION
vscode 1.60 unterstützt dieses feature nativ, man brauch keine extension mehr

ich würde mit mergen warten bis stable auf 1.60 gezogen ist. was meint ihr?
(falls jemand nicht latest eingestellt hat)

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/120"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

