### PR TITLE
Keine Zeilenummerierung bei mint

### DIFF
--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -34,6 +34,22 @@ Siehe Quelltext.
     \caption{Beispielcode}
     \label{code:example}
 \end{code}
+An dieser Stelle wird noch ein einzeiliger Code eingefügt, der keine Zeilennummerierung erhalten soll.
+Dies kann genutzt werden, wenn man nur kurz auf eine Funktion eingehen möchte und diese nicht im Quellcodeverzeichnis erscheinen soll.
+\mint{python}|print("Hallo Vorlage")|
+
+Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktioniert.
+
+\begin{code}[H]
+  \begin{minted}{python}
+      class Wooo(Foo):
+          def __init__(self, boo):
+              self.doo = boo
+              moo = 1 + 2 +3
+  \end{minted}
+  \caption{Beispielcode}
+  \label{code:example2}
+\end{code}
 
 \subsection{Ordnerstruktur}
     \verzeichnis{%

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -370,12 +370,10 @@
 \linespread{1.3}
 \newcommand\frontmatter{%
     \cleardoublepage
-  %\@mainmatterfalse
   \pagenumbering{Roman}}
 
 \newcommand\mainmatter{%
     \cleardoublepage
- % \@mainmattertrue
   \pagenumbering{arabic}}
 
 \newcommand\backmatter{%
@@ -384,7 +382,6 @@
   \else
     \clearpage
   \fi
- % \@mainmatterfalse
    }
 
 %! Inhalts-/Anhangsverzeichnis

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -422,6 +422,8 @@
 
 %Zeilennummern neu definieren, um Warnungen zu vermeiden und modern anmutende Zahlen zu nutzen
 \renewcommand{\theFancyVerbLine}{\scriptsize{\arabic{FancyVerbLine}}}
+
+%Standardformatierung für minted-Umgebung erstellen
 \setminted{
     tabsize=2,
     breaklines,
@@ -431,6 +433,9 @@
     %! see https://pygments.org/demo/#try, other nice options: paraiso-light, solarized-light, rainbow_dash, gruvbox-light, stata, tango
     style=emacs
 }
+%Keine Zeilennnummer, wenn der einzeilige \mint-Befehl genutzt wird
+\xpretocmd{\mint}{\setminted{linenos=false}}{}{}
+\xpretocmd{\minted}{\setminted{linenos=true}}{}{}
 
 %! Eigene Befehle zur erleichterten Nutzung
 % Hilfsbefehle


### PR DESCRIPTION
- Keine Zeilenummerierung bei `\mint{python}|print("Hallo Vorlage!")|

- Veraltete Befehle aus der vorlage.tex entfernt

Fixes #131 