### PR TITLE
timeout für actions-workflow

### DIFF
--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-pdf:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v2
       - name: Determine container version
@@ -29,7 +29,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 3
     steps:
       - name: Checkout commit before push
         if: |


### PR DESCRIPTION
* falls ein build hängen sollte, sollte dieser nicht erst nach 6h (default timeout) als fehlgeschlagen markiert werden
* es gibt leider keine workflow-level-timeouts, daher ein pro job
* realistischerweise wird nur maximal ein timeout komplett ausgereizt, d.h. die maximale laufzeit ist [buildzeit HEAD] + 5 min (timeout diff)

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/137"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

