### PR TITLE
Fix für Großschreibung von Autoren in Quellenverzeichnis

### DIFF
--- a/Latex/literatur.bib
+++ b/Latex/literatur.bib
@@ -16,32 +16,12 @@
   urldate = {2021-08-17},
   }
 
-@Online{LAMPORT,
-  author  = {Leslie Lamport},
-  title   = {The LaTeX Project},
-  url     = {https://www.latex-project.org/},
-  urldate = {2020-07-15},
-}
-
 @Online{HAWA,
   author   = {{Staatliche Studienakademie Glauchau}},
   title    = {Hinweise zur Anfertigung wissenschaftlicher Arbeiten},
   url      = {https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_Hinweise_zur_Anfertigung_wissenschaftlicher_Arbeiten.pdf},
   urldate  = {2020-06-12},
   keywords = {HAWA, arbeiten, vorlage, latex},
-}
-
-@Book{KOHM2020,
-  author    = {Kohm, Markus},
-  date      = {2020-02-07},
-  title     = {KOMA-Script},
-  edition   = {7. überarbeitete und erweiterte Auflage},
-  isbn      = {3965430971},
-  location  = {Köln},
-  publisher = {Lehmanns Media GmbH},
-  url       = {https://www.ebook.de/de/product/38407462/markus_kohm_koma_script.html},
-  ean       = {9783965430976},
-  year      = {2020},
 }
 
 @Comment{jabref-meta: databaseType:biblatex;}

--- a/Latex/literatur.bib
+++ b/Latex/literatur.bib
@@ -24,7 +24,7 @@
 }
 
 @Online{HAWA,
-  author   = {Staatliche-Studienakademie-Glauchau},
+  author   = {{Staatliche Studienakademie Glauchau}},
   title    = {Hinweise zur Anfertigung wissenschaftlicher Arbeiten},
   url      = {https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_Hinweise_zur_Anfertigung_wissenschaftlicher_Arbeiten.pdf},
   urldate  = {2020-06-12},

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -278,12 +278,15 @@
 
 \urlstyle{same}
 \DeclareNameFormat{author}{%
-      \nameparts{#1}%
-      \usebibmacro{name:family-given}
-        {\MakeUppercase{\namepartfamily}}
-        {\namepartgiven}
-        {\namepartprefix}
-        {\namepartsuffix}%
+  \nameparts{#1}%
+  \usebibmacro{name:family-given}
+    {\expandafter\ifblank\expandafter{\namepartgiven}
+       {\namepartfamily}% no family name, don't uppercase
+       {\MakeUppercase{\namepartfamily}}%
+    }
+    {\namepartgiven}
+    {\namepartprefix}
+    {\namepartsuffix}%
 }
 \DeclareFieldFormat{title}{#1}
 


### PR DESCRIPTION
laut [https://tex.stackexchange.com/a/621011/255865](https://tex.stackexchange.com/a/621011/255865)

![grafik](https://user-images.githubusercontent.com/24256864/139840756-1e39de4f-ad93-4c4a-8d93-9685d31deabf.png)

fixes #138 

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/139"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

