### PR TITLE
Fontenc nutzen, um Umlaute korrekt zu codieren

### DIFF
--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -71,6 +71,7 @@
 \usepackage{float}
 \usepackage[a4paper,lmargin={2.5cm},rmargin={2.5cm},tmargin={2cm},bmargin={2cm}]{geometry}
 \usepackage{lineno}
+\usepackage[T1]{fontenc}
 \usepackage{csquotes}
 \usepackage{listings}
 \usepackage{tikz}


### PR DESCRIPTION
Fixes #114 
Außerdem werden dadurch Sonderzeichen durch die Schriftart statt durch LaTeX bestimmt. Das sorgt für eine veränderte Darsgtellung, bspw. bei Unterstrichen:

Vorher: 
![grafik](https://user-images.githubusercontent.com/24256864/140030568-8d59105e-8615-4f8f-8f25-84c41dcef13d.png)
Nachher:
![grafik](https://user-images.githubusercontent.com/24256864/140030591-931b313c-6a9b-4665-8a4a-21418dcfc8b7.png)
Diff:
![grafik](https://user-images.githubusercontent.com/24256864/140030609-a7bcb0f3-782c-4691-a93c-8e64d2936602.png)

Erklärung: https://tex.stackexchange.com/questions/621131/fontenc-t1-changes-underscores