### PR TITLE
mehr als 3 Autoren korrigiert

### DIFF
--- a/Latex/literatur.bib
+++ b/Latex/literatur.bib
@@ -1,8 +1,8 @@
 % Encoding: UTF-8
 
-@Online{SCZYRBA2020,
+@Online{Vorlage,
   author  = {Sczyrba, Dominic and Pohle, Colin and Hille, Willy},
-  date    = {2020},
+  date    = {2021},
   title   = {LaTeX Vorlage Staatliche Studienakademie Glauchau},
   url     = {https://github.com/DSczyrba/Vorlage-Latex},
   urldate = {2020-07-15},
@@ -22,6 +22,35 @@
   url      = {https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_Hinweise_zur_Anfertigung_wissenschaftlicher_Arbeiten.pdf},
   urldate  = {2020-06-12},
   keywords = {HAWA, arbeiten, vorlage, latex},
+}
+
+@misc{rfc3596,
+	series =	{Request for Comments},
+	number =	3596,
+	howpublished =	{RFC 3596},
+	publisher =	{RFC Editor},
+	doi =		{10.17487/RFC3596},
+	url =		{https://rfc-editor.org/rfc/rfc3596.txt},
+  author =	{Vladimir Ksinant and Christian Huitema and Dr. Susan Thomson and Mohsen Souissi},
+	title =		{{DNS Extensions to Support IP Version 6}},
+	pagetotal =	8,
+	date =		2003,
+	month =		oct,
+	urldate = {2021-09-09},
+	abstract =	{This document defines the changes that need to be made to the Domain Name System (DNS) to support hosts running IP version 6 (IPv6). The changes include a resource record type to store an IPv6 address, a domain to support lookups based on an IPv6 address, and updated definitions of existing query types that return Internet addresses as part of additional section processing. The extensions are designed to be compatible with existing applications and, in particular, DNS implementations themselves. {[}STANDARDS-TRACK{]}},
+}
+
+@Book{KOHM2020,
+  author    = {Kohm, Markus},
+  date      = {2020-02-07},
+  title     = {KOMA-Script},
+  edition   = {7. überarbeitete und erweiterte Auflage},
+  isbn      = {3965430971},
+  location  = {Köln},
+  publisher = {Lehmanns Media GmbH},
+  url       = {https://www.ebook.de/de/product/38407462/markus_kohm_koma_script.html},
+  ean       = {9783965430976},
+  year      = {2020},
 }
 
 @Comment{jabref-meta: databaseType:biblatex;}

--- a/Latex/literatur.bib
+++ b/Latex/literatur.bib
@@ -21,6 +21,7 @@
   title    = {Hinweise zur Anfertigung wissenschaftlicher Arbeiten},
   url      = {https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_Hinweise_zur_Anfertigung_wissenschaftlicher_Arbeiten.pdf},
   urldate  = {2020-06-12},
+  date     = {2018},
   keywords = {HAWA, arbeiten, vorlage, latex},
 }
 

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -2,7 +2,7 @@
 \section{Einleitung}
 Diese PDF wurde mit der Vorlage erstellt, um die Funktion und Formatierung dieser zu zeigen.
 
-Die Vorlage\onlinezitat{SCZYRBA2020} ist ein Gemeinschaftsprojekt im Rahmen unseres Studiums.
+Die Vorlage\onlinezitat{Vorlage} ist ein Gemeinschaftsprojekt im Rahmen unseres Studiums.
 Der Docker-Container\onlinezitat{HILLE2021} gehört dazu.
 Die Vorlage richtet sich weitestgehend nach dem Dokument \ac{HAWA}\onlinezitat{HAWA} der \href{https://www.ba-glauchau.de/}{Staatlichen Studienakademie Glauchau}.
 
@@ -120,3 +120,5 @@ Zeile 2 & & mit \emph{\textbackslash hsize}\\
 \caption{Beispieltabelle}
 \label{beispieltabelle}
 \end{table}
+
+In diesem Satz wird eine Quelle mit nur einem Autor zitiert\onlinezitat{HAWA}, eine mit drei Autoren\onlinezitat{Vorlage} und eine Quelle mit vier Autoren\onlinezitat{rfc3596}, welche als \emph{Autor 1; u.a.} dargestellt werden sollte. Es folgt ein Buch-Zitat\zitat{KOHM2020}.

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -16,7 +16,13 @@
 
 \usepackage{tocbasic}
 \usepackage[ngerman]{babel}
-\usepackage[backend=biber, labeldateparts=true, style=authortitle, isbn=false, dashed=false]{biblatex}
+\usepackage[%
+  backend=biber,
+  labeldateparts=true,
+  style=authortitle,
+  isbn=false,
+  dashed=false,
+  maxnames=3]{biblatex}
 
 %! Das Inhaltsverzeichnis wird an dieser Stelle formatiert.
 \RedeclareSectionCommands[beforeskip=-.1\baselineskip, afterskip=.1\baselineskip, tocindent=0pt, tocnumwidth=45pt]{section,subsection,subsubsection}
@@ -77,6 +83,7 @@
 \usepackage{tikz}
 \usepackage{dirtree}
 \usepackage{varwidth}
+\usepackage{ifthen}
 
 %! Centered Dirtree - https://tex.stackexchange.com/posts/100182/revisions
 \makeatletter
@@ -288,6 +295,7 @@
     {\namepartgiven}
     {\namepartprefix}
     {\namepartsuffix}%
+    \ifthenelse{\value{listcount}=1\AND\ifmorenames}{\andothersdelim\bibstring{andothers}}{}%
 }
 \DeclareFieldFormat{title}{#1}
 
@@ -295,6 +303,7 @@
 \renewcommand{\finalnamedelim}{\addsemicolon\space}
 \renewcommand{\labelnamepunct}{\addcolon\space}
 \renewcommand*{\finentrypunct}{}
+\renewcommand{\andothersdelim}{\addsemicolon\space}
 
 \setlength\bibitemsep{\baselineskip}
 \setlength\bibhang{0pt}
@@ -307,7 +316,7 @@
   {\usebibmacro{prenote}}
   {\usebibmacro{citeindex}
    \setunit{\addnbspace}
-   \bibhyperref{\printnames[author][1-3]{labelname}}
+   \bibhyperref{\printnames[author]{labelname}}
    \setunit{\labelnamepunct}
    \newunit
    \printfield{location}
@@ -325,7 +334,7 @@
   {\usebibmacro{citeindex}
    \setunit{\addnbspace}
    online:
-   \bibhyperref{\printnames[author][1-3]{labelname}}
+   \bibhyperref{\printnames[author]{labelname}}
    \setunit{\labelnamepunct}
    \newunit
    \printfield{labelyear}\printfield{extradate}

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -338,7 +338,6 @@
    \setunit{\labelnamepunct}
    \newunit
    \printfield{labelyear}\printfield{extradate}
-   \newunit
    \printtext{(}\printfield{urlday}\printtext{.}\printfield{urlmonth}\printtext{.}\printfield{urlyear}\printtext{)}}
   {\addsemicolon\space}
   {\usebibmacro{postnote}}


### PR DESCRIPTION
- fixes #145
- entfernt außerdem ein überflüssiges Komma vor dem Abrufdatum einer Online-Quelle
- Beispielzitate in Doku-Test.tex

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/146"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

