### PR TITLE
Verschiedene Änderungen

### DIFF
--- a/Latex/inhalt/Anhang.tex
+++ b/Latex/inhalt/Anhang.tex
@@ -20,20 +20,20 @@
 
 %! Anpassung der Darstellung von Abbildungen im Anhang
 %! Eine Variante auskommentieren
-%? Möglichkeit 1: ohne Nummerierung und ohne "Abbildung"
-%\renewcommand{\bild}[3][1.0]{\begin{figure}[H]
-%    \centering
-%    \includegraphics[width=#1\columnwidth]{bilder/#2}
-%    \caption*{#3}
-%    \label{#3}
-%    \end{figure}}
+%? Möglichkeit 1: ohne Nummerierung
+%\renewcommand{\bild}[4][1.0]{\begin{figure}[H]
+    %\centering
+    %\includegraphics[width=#1\columnwidth]{bilder/#2}
+    %\caption*{\bfseries Abbildung \mdseries #3}
+    %\label{#4}
+    %\end{figure}}
 
-%? Möglichkeit 2: mit Nummerierung und "Abbildung", aber nicht im Abbildungsverzeichnis
-\renewcommand{\bild}[3][1.0]{\begin{figure}[H]
+%? Möglichkeit 2: mit Nummerierung aber nicht im Abbildungsverzeichnis
+\renewcommand{\bild}[4][1.0]{\begin{figure}[H]
     \centering
     \includegraphics[width=#1\columnwidth]{bilder/#2}
     \caption[]{#3}
-    \label{#3}
+    \label{#4}
     \end{figure}}
 
 %! Anhang 1

--- a/Latex/inhalt/Anhang.tex
+++ b/Latex/inhalt/Anhang.tex
@@ -7,12 +7,15 @@
 %! Section Befehl wird umgeschrieben, um Überschriften zu verbergen
 %! Kann, falls Überschriften gewollt sind, entfernt oder erst später eingefügt werden.
 % Beginn
-\renewcommand{\section}[1]{
-\par\refstepcounter{section}
-\sectionmark{#1}
-\addcontentsline{atoc}{section}{\bfseries\protect\numberline{\thesection}{\mdseries#1}}
-\lohead{\textnormal{#1}}
+\makeatletter
+\renewcommand{\section}[1]{%
+\par\refstepcounter{section}%
+\sectionmark{#1}%
+\NR@gettitle{#1}%<---------
+\addcontentsline{atoc}{section}{\bfseries\protect\numberline{\thesection}{\mdseries#1}}%
+\lohead{\textnormal{#1}}%
 }
+\makeatother
 % Ende
 
 %! Anpassung der Darstellung von Abbildungen im Anhang

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -247,7 +247,7 @@
 \hypersetup{pdfsubject={\kurzbeschreibung}}
 \hypersetup{pdfauthor={\autoren}}
 \usepackage[numbered]{bookmark}
-\usepackage{acronym}
+\usepackage[printonlyused]{acronym}
 \usepackage{enumitem}
 
 %Abkürzungsverzeichnis - Formatierung (bspw. zur korrekten Anzeige von BASH-Befehlen)

--- a/Latex/vorlage/vorlage_commands.tex
+++ b/Latex/vorlage/vorlage_commands.tex
@@ -39,8 +39,8 @@
 
 % Anhänge - Sonderbehandlung, da nameref auf Anhänge nicht funktioniert
 % https://github.com/DSczyrba/Vorlage-Latex/issues/29
-\newcommand{\litearef}[1]{\emph{\hyperref[{#1}]{Anhang \ref{#1}}}}
-\newcommand{\fullaref}[1]{(\emph{\hyperref[{#1}]{siehe Anhang \ref{#1}}})}
+\newcommand{\litearef}[1]{\uniliteref{Anhang}{#1}}
+\newcommand{\fullaref}[1]{\unifullref{Anhang}{#1}}
 \newcommand{\aref}[1]{\litearef{#1}}
 % Abbildungen
 \newcommand{\litebref}[1]{\uniliteref{Abbildung}{#1}}


### PR DESCRIPTION
- Akronym gibt im Abkürzungsverzeichnis nur noch genutze Abkürzungen aus
- Refernzierung von Anhängen funktioniert
- im Anhang neu definiertes "bild"-Kommando angepasst

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/151"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

