### PR TITLE
Automatische Versionen für 1-4 Autoren

### DIFF
--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -4,6 +4,8 @@ Hier befinden sich einige Hinweise, wie verschiedene Anforderungen der HAWA umge
 
 - Metadaten (Titel, Autor(en), Matrikelnummer(n) usw.) werden in die Datei `metadaten.sty` eingetragen und dann im Dokument und in den PDF-Metadaten verwendet. Die Kommandos dazu können natürlich überall verwendet werden. Sollte ein sehr langer Titel gewählt werden, ist es möglich, dass dieser auf den Titelseiten oder den Erklärungen zu Problemen führt. Diese müssen in den jeweiligen Titelseiten- (verringerte Abstände und/oder Schriftgröße) bzw. Erklärungsdateien (zusätzliche Zeilen) behoben werden.
 
+- Anhand der Metadaten wird automatisch entschieden, welche Versionen der Titelseite und Erklärungen verwendet werden und ob Abstract zur Bachelorarbeit und Freigabeerklärung aktiviert werden.
+
 - Fußnoten sollten durch `\fn{Fußnotentext}`, Online-Zitate durch `\onlinezitat{key}`, andere Zitate durch `\zitat{key}` eingetragen werden. Beispiele dazu, wie Quellen zu speichern sind, sind in `literatur.bib` zu finden.
 
 - Mit `\label{bezeichner:name}` können Bezeichner für Elemente erstellt werden. Auf diese kann über LaTeX-eigene oder in `vorlage/vorlage-commands.tex` definierte Kommandos zugegriffen werden.

--- a/Latex/inhalt/Anhang.tex
+++ b/Latex/inhalt/Anhang.tex
@@ -36,14 +36,9 @@
     \label{#4}
     \end{figure}}
 
-%! Anhang 1
-\section{Erster Anhang}
-\label{sec:anhang1}
-Der erste Anhang der Arbeit.
-\clearpage
-
-%! Anhang 2
+%! CD-Inhalt
 \section{Inhalt der CD}
+\label{cd-inhalt}
 CD mit folgenden Inhalten:
 \begin{itemize}
     \item dieses Dokument
@@ -54,17 +49,15 @@ CD mit folgenden Inhalten:
 
 % Warnungen für vorgefertigte Dokumente deaktivieren
 \hbadness=10000
-%  Eidestattliche Erklärung und Erklärung zur Prüfung wissenschaftlicher Arbeiten
-%! hier zwischen Version für einen oder mehrere Autoren umschalten
-\input{vorlage/Erklärung_1Autor}
-%\input{vorlage/Erklärung_2Autoren}
-%\input{vorlage/Erklärung_3Autoren}
-%\input{vorlage/Erklärung_4Autoren}
+% automatische Auswahl der Erklärungen
+\ifthenelse{\isundefined{\autorzwei}}{\input{vorlage/Erklärung_1Autor}}{%
+    \ifthenelse{\isundefined{\autordrei}}{\input{vorlage/Erklärung_2Autoren}}{%
+        \ifthenelse{\isundefined{\autorvier}}{\input{vorlage/Erklärung_3Autoren}}{\input{vorlage/Erklärung_4Autoren}}
+    }
+}
 
 %  Abstract und Freigabeerklärung zur Bachelorthesis
 %! Falls nötig (z.B. bei Diplomarbeit) innerhalb der Datei Wortlaut anpassen, sowie Freigabeerklärung anpassen (erfordert Format Name, Vorname usw.)
-
-%\input{vorlage/Abstract_Freigabeerklärung_Bachelorthesis}
-
+\ifthenelse{\isundefined{\jahr}}{}{\input{vorlage/Abstract_Freigabeerklärung_Bachelorthesis}}
 % Warnungen zurücksetzen
 \hbadness=1000

--- a/Latex/main.tex
+++ b/Latex/main.tex
@@ -12,11 +12,12 @@
 %! Inhalt der Arbeit
 \frontmatter
 
-%! Auswahl der Titelseite
-\include{vorlage/Titelseite_1Autor}
-%\include{vorlage/Titelseite_2Autoren}
-%\include{vorlage/Titelseite_3Autoren}
-%\include{vorlage/Titelseite_4Autoren}
+%! automatische Auswahl der Titelseite
+\ifthenelse{\isundefined{\autorzwei}}{\include{vorlage/Titelseite_1Autor}}{%
+    \ifthenelse{\isundefined{\autordrei}}{\include{vorlage/Titelseite_2Autoren}}{%
+        \ifthenelse{\isundefined{\autorvier}}{\include{vorlage/Titelseite_3Autoren}}{\include{vorlage/Titelseite_4Autoren}}
+    }
+}
 
 %! Nicht benötigte Verzeichnisse hier auskommentieren
 %? Inhaltsverzeichnis

--- a/Latex/metadaten.sty
+++ b/Latex/metadaten.sty
@@ -1,34 +1,26 @@
-%Autor 1:
-\newcommand{\autoreins}{Name 1}
-%Autor 2:
-\newcommand{\autorzwei}{}
-%Autor 3:
-\newcommand{\autordrei}{}
-%Autor 4:
-\newcommand{\autorvier}{}
-%Autoren - für PDF Titel - anpassen, falls nicht alle genutzt werden
-\newcommand{\autoren}{{\autoreins}, {\autorzwei}, {\autordrei}, \autorvier}
+%! Für zusätzliche Autoren '%' vor entsprechenden Zeilen entfernen, Reihenfolge beachten!
+%   Autor/Matrikelnummer 1:
+\newcommand{\autoreins}{Name 1}\newcommand{\matnumeins}{4001234}
+%   Autor/Matrikelnummer 2:
+\newcommand{\autorzwei}{Name 2}\newcommand{\matnumzwei}{4001235}
+%   Autor/Matrikelnummer 3:
+\newcommand{\autordrei}{Name 3}\newcommand{\matnumdrei}{4001236}
+%   Autor/Matrikelnummer 4:
+%\newcommand{\autorvier}{Name 4}\newcommand{\matnumvier}{4001237}
 %Adressdaten für Praxisbeleg:
 \newcommand{\autorstrasse}{Straße Hausnummer Autor}
 \newcommand{\autorort}{Postleitzahl Ort Autor}
 \newcommand{\partnerstrasse}{Straße Hausnummer Praxispartner}
 \newcommand{\partnerort}{Postleitzahl Ort Praxispartner}
-%Matrikelnummer 1:
-\newcommand{\matnumeins}{4001234}
-%Matrikelnummer 2:
-\newcommand{\matnumzwei}{4001235}
-%Matrikelnummer 3:
-\newcommand{\matnumdrei}{4001236}
-%Matrikelnummer 4:
-\newcommand{\matnumvier}{4001237}
 %Titel:
 \newcommand{\titel}{Titel der Arbeit}
 %Kurzbeschreibung:
 \newcommand{\kurzbeschreibung}{Beschreibung der Arbeit}
 %Vorgelegt am:
 \newcommand{\abgabedatum}{Abgabedatum}
-%Jahr (nur für Abstract zur Bachelorthesis nötig)
-\newcommand{\jahr}{Jahr}
+%   Jahr wird nur für den Abstract zur Bachelorthesis benötigt.
+%   Das folgende Kommando zu aktivieren, aktiviert Abstract und Freigabeerklärung
+%\newcommand{\jahr}{Jahr}
 %Studiengang:
 \newcommand{\studiengang}{Studiengang}
 %Seminargruppe:

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -98,7 +98,7 @@ Gegenstand & Beispiel & Anmerkungen \\
 \hline
 Kurzer Verweis auf Kapitel & \literef{sec:beispiele} & \\
 \hline
-Kurzer Verweis auf Anhang & \litearef{sec:anhang1} & Alias: \emph{\textbackslash aref} \\
+Kurzer Verweis auf Anhang & \litearef{cd-inhalt} & Alias: \emph{\textbackslash aref} \\
 \hline
 Kurzer Verweis auf Abbildung & \litebref{beispielbaum} & Alias: \emph{\textbackslash bref} \\
 \hline
@@ -106,7 +106,7 @@ Kurzer Verweis auf Tabelle & \litetref{beispieltabelle} & Alias: \emph{\textback
 \hline
 Langer Verweis auf Kapitel & \fullref{sec:beispiele} & \\
 \hline
-Langer Verweis auf Anhang & \fullaref{sec:anhang1} &  \\
+Langer Verweis auf Anhang & \fullaref{cd-inhalt} &  \\
 \hline
 Langer Verweis auf Abbildung & \fullbref{beispielbaum} &  \\
 \hline

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -245,7 +245,13 @@
 \usepackage[hidelinks]{hyperref}
 \hypersetup{pdftitle={\titel}}
 \hypersetup{pdfsubject={\kurzbeschreibung}}
-\hypersetup{pdfauthor={\autoren}}
+\ifthenelse{\isundefined{\autorzwei}}{\hypersetup{pdfauthor={\autoreins}}}{%
+    \ifthenelse{\isundefined{\autordrei}}{\hypersetup{pdfauthor={\autoreins, \autorzwei}}}{%
+        \ifthenelse{\isundefined{\autorvier}}{\hypersetup{pdfauthor={\autoreins, \autorzwei, \autordrei}}}{%
+        \hypersetup{pdfauthor={\autoreins, \autorzwei, \autordrei, \autorvier}}
+        }
+    }
+}
 \usepackage[numbered]{bookmark}
 \usepackage[printonlyused]{acronym}
 \usepackage{enumitem}


### PR DESCRIPTION
- automatisches Umschalten zwischen Erklärung / Titelseite für 1-4 Autoren anhand Metadaten.sty
- automatische Aktivieren des Abstracts / der Freigabeerklärung anhand Metadaten.sty
- automatisches Füllen der Autorenliste in den PDF-Metadaten, fixes #128 
- sinnlosen ersten Anhang entfernt und Doku-Test.tex entsprechend angepasst

fixes #50

<a href="https://gitpod.io/#https://github.com/DSczyrba/Vorlage-Latex/pull/154"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

