### PR TITLE
ref: Change BA to DHSN

### DIFF
--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -7,7 +7,7 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
 - Metadaten (Titel, Autor(en), Matrikelnummer(n) usw.) werden in die Datei `metadaten.sty` eingetragen und dann im Dokument und in den PDF-Metadaten verwendet. Die Kommandos dazu können natürlich überall verwendet werden. Sollte ein sehr langer Titel gewählt werden, ist es möglich, dass dieser auf den Titelseiten oder den Erklärungen zu Problemen führt. Diese müssen in den jeweiligen Titelseiten- (verringerte Abstände und/oder Schriftgröße) bzw. Erklärungsdateien (zusätzliche Zeilen) behoben werden.
 - Anhand der Metadaten wird automatisch entschieden, welche Versionen der Titelseite und Erklärungen verwendet werden.
 - In der Datei `main_abstract.tex` befindet sich das Abstract, da beide dieses einzeln Einzulegen ist.
-- Zwischen Deckblatt und Themenblatt ist (bei Bachelor-/Diplom-Thesen) die [Freigabeerklärung](https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.300_Freigabeerkla__rung_Thesis_ausfu__llbar.pdf) der BA Glauchau einzufügen!
+- Zwischen Deckblatt und Themenblatt ist (bei Bachelor-/Diplom-Thesen) die Freigabeerklärung (nur intern zu finden, Stand 2025-11-04) der DHSN Glauchau einzufügen!
 
 ## Fußnoten und Referenzen
 
@@ -110,7 +110,7 @@ Für weitere Details zu Referenzen siehe `Doku-Test.tex` bzw. die standardmäßi
 
 - Soll ein Float unbedingt exakt an der selben Stelle wie im Quellcode platziert werden, kann dies mit `[H]` erzwungen werden (bspw. `\begin{table}[H]`).
 
-- In Floats wird standardmäßig ebenfalls der durch die BA geforderte Zeilenabstand von 1,3 genutzt. Falls hier ein kleinerer Zeilenabstand gewünscht ist, kann dieser manuell per `\linespread{1}` innerhalb des Floats oder global durch Entfernen der zu diesem Zweck in `vorlage.tex` auf `\usepackage{setspace}` folgend eingesetzten Zeilen auf 1 gesetzt werden.
+- In Floats wird standardmäßig ebenfalls der durch die DHSN geforderte Zeilenabstand von 1,3 genutzt. Falls hier ein kleinerer Zeilenabstand gewünscht ist, kann dieser manuell per `\linespread{1}` innerhalb des Floats oder global durch Entfernen der zu diesem Zweck in `vorlage.tex` auf `\usepackage{setspace}` folgend eingesetzten Zeilen auf 1 gesetzt werden.
 
 ## Sonstiges
 

--- a/Latex/main.tex
+++ b/Latex/main.tex
@@ -15,8 +15,8 @@
 %! automatische Auswahl der Titelseite
 \ifthenelse{\isundefined{\autorzwei}}{\include{vorlage/Titelseite_1Autor}}{\include{vorlage/Titelseite_mehrere_Autoren}}
 \vfuzz=10pt
-%! Die laut HAWA obligatorische "Einwilligungserklärung in die Archivierung und Veröffentlichung der Bachelor-Thesis/Diplomarbeit an der Berufsakademie Sachsen" ist an dieser Stelle einzufügen!
-%! Das BA-Dokument beinhaltet nicht die Möglichkeit, diese Arbeit vollständig (gegen Einsicht) zu sperren - diesen Zweck erfüllt der Sperrvermerk.
+%! Die laut HAWA obligatorische "Einwilligungserklärung in die Archivierung und Veröffentlichung der Bachelor-Thesis/Diplomarbeit an der Dualen Hochschule Sachsen" ist an dieser Stelle einzufügen!
+%! Das DHSN-Dokument beinhaltet nicht die Möglichkeit, diese Arbeit vollständig (gegen Einsicht) zu sperren - diesen Zweck erfüllt der Sperrvermerk.
 \ifthenelse{\isundefined{\sperre}}{}{\include{vorlage/Sperrvermerk}}
 \vfuzz=0.1pt
 

--- a/Latex/metadaten.sty
+++ b/Latex/metadaten.sty
@@ -40,8 +40,8 @@
 %Betreuer 1:
 \newcommand{\betreuereins}{Betreuer Praxispartner}
 %Betreuer 2:
-\newcommand{\betreuerzwei}{Betreuer BA}
+\newcommand{\betreuerzwei}{Betreuer DHSN}
 %Institution 1:
 \newcommand{\institutioneins}{Firma Praxispartner}
 %Institution 2:
-\newcommand{\institutionzwei}{Staatliche Studienakademie Glauchau}
+\newcommand{\institutionzwei}{Duale Hochschule Glauchau}

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -4,7 +4,7 @@ Diese PDF wurde mit der Vorlage erstellt, um die Funktion und Formatierung diese
 
 Die Vorlage\onlinezitat{Vorlage} ist ein Gemeinschaftsprojekt im Rahmen unseres Studiums.
 Der Docker-Container\onlinezitat{HILLE2021} gehört dazu.
-Die Vorlage richtet sich weitestgehend nach dem Dokument \ac{HAWA}\onlinezitat{HAWA} der \href{https://www.ba-glauchau.de/}{Staatlichen Studienakademie Glauchau}.
+Die Vorlage richtet sich weitestgehend nach dem Dokument \ac{HAWA}\onlinezitat{HAWA} der \href{https://www.dhsn.de/glauchau}{Dualen Hochschule Glauchau}.
 
 Weitere Hinweise befinden sich in der README.md oder im \href{https://github.com/DSczyrba/Vorlage-Latex/wiki}{Wiki}.
 Eine ausführliche Dokumentation zu diesem Dokument wird folgen.

--- a/Latex/vorlage/Erklärung.tex
+++ b/Latex/vorlage/Erklärung.tex
@@ -1,6 +1,6 @@
 %  Eidesstattliche Erklärung
 %! Dies ist eine zur Nutzung mit LaTeX angepasste Version der in Anhang 6 der Hinweise zur Anfertigung
-%! wissenschaftlicher Arbeiten an der Staatlichen Studienakademie Glauchau vorgegebenen Zustimmung
+%! wissenschaftlicher Arbeiten an der Dualen Hochschule Glauchau vorgegebenen Zustimmung
 %! zur Plagiatsprüfung für Praxisbelege.
 \cleardoublepage
 \lohead{\textnormal{Eidesstattliche Erklärung}}
@@ -56,9 +56,9 @@
           \textbf{\huge{Erklärung zur Prüfung wissenschaftlicher Arbeiten}}
       \end{center}
 
-      Die Bewertung wissenschaftlicher Arbeiten erfordert die Prüfung auf Plagiate. Die hierzu von der Staatlichen Studienakademie Glauchau eingesetzte Prüfungskommission nutzt sowohl eigene Software als auch diesbezügliche Leistungen von Drittanbietern. Dies erfolgt gemäß \href{https://www.revosax.sachsen.de/vorschrift/1672-Saechsisches-Datenschutzgesetz#p7}{§ 7 des Gesetzes zum Schutz der informationellen Selbstbestimmung im Freistaat Sachsen (Sächsisches Datenschutzgesetz - SächsDSG)} vom 25. August 2003 (Rechtsbereinigt mit Stand vom 31. Juli 2011) im Sinne einer Datenverarbeitung im Auftrag.
+      Die Bewertung wissenschaftlicher Arbeiten erfordert die Prüfung auf Plagiate. Die hierzu von der DHSN Glauchau eingesetzte Prüfungskommission nutzt sowohl eigene Software als auch diesbezügliche Leistungen von Drittanbietern. Dies erfolgt gemäß \href{https://www.revosax.sachsen.de/vorschrift/1672-Saechsisches-Datenschutzgesetz#p7}{§ 7 des Gesetzes zum Schutz der informationellen Selbstbestimmung im Freistaat Sachsen (Sächsisches Datenschutzgesetz - SächsDSG)} vom 25. August 2003 (Rechtsbereinigt mit Stand vom 31. Juli 2011) im Sinne einer Datenverarbeitung im Auftrag.
 
-      Der Studierende bevollmächtigt die Mitglieder der Prüfungskommission hiermit zur Inanspruchnahme o. g. Dienste. In begründeten Ausnahmefällen kann der Datenschutzbeauftragte der Berufsakademie Sachsen sowohl vom Verfasser der wissenschaftlichen Arbeit als auch von der Prüfungskommission in den Entscheidungsprozess einbezogen werden.
+      Der Studierende bevollmächtigt die Mitglieder der Prüfungskommission hiermit zur Inanspruchnahme o. g. Dienste. In begründeten Ausnahmefällen kann der Datenschutzbeauftragte der Dualen Hochschule Sachsen sowohl vom Verfasser der wissenschaftlichen Arbeit als auch von der Prüfungskommission in den Entscheidungsprozess einbezogen werden.
 
       \ifthenelse{\isundefined{\autorzwei}}{%
         \arrayrulewidth=0.5pt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vorlage-Latex
 
-Dies ist eine LaTeX-Vorlage für wissenschaftliche Arbeiten (Belege, Bachelorthesen usw.) an der [Staatlichen Studienakademie Glauchau (BA Glauchau)](https://www.ba-glauchau.de/) und entspricht weitestgehend den [Hinweisen zur Anfertigung wissenschaftlicher Arbeiten (HAWA)](https://www.ba-glauchau.de/fileadmin/glauchau/waehrend-des-studium/dokumente/pruefungen/4BA-F.207_HAWA_V5_1_1.pdf) in der zu diesem Zeitpunkt aktuellen Version 5.1.1.
+Dies ist eine LaTeX-Vorlage für wissenschaftliche Arbeiten (Belege, Bachelorthesen usw.) an der [Dualen Hochschule Sachsen (Standort Glauchau)](https://www.dhsn.de/glauchau) und entspricht weitestgehend den "Hinweisen zur Anfertigung wissenschaftlicher Arbeiten (HAWA)" (nicht mehr öffentlich verfügbar, Stand 2025-11-04) in der zu diesem Zeitpunkt aktuellen Version 5.1.2.
 
 Die Vorlage unterstützt aktuell 1-4 Autoren. Bei einem Autor wird von einem Praxisbeleg bzw. einer Bachelor-Thesis ausgegangen, bei mehreren von einer Projektarbeit. Sollte ein anderer Typ Arbeit nötig sein, muss dies in den entsprechen Dateien im Ordner `vorlage` manuell angepasst werden. Eine Parametrisierung ist nicht möglich, da eine Änderung des Typs eine Anpassung der Grammatik, beispielsweise der Ehrenwörtlichen Erklärung, nötig machen kann.
 


### PR DESCRIPTION
The Berufsakademie changed to a Duale Hochschule. This PR changes the naming from "BA / Berufsakademie" die "DHSN / Duale Hochschule Glauchau". I chose different namings so that search engines have a higher chance of finding this repo when searching for different names. 
It furthermore changes the HAWA version to 5.1.2, as I forgot that in my last PR https://github.com/ba-latex/Vorlage-Latex/pull/239 .
I added a notice that the mentioned documents are no longer publicly available.
I'd furthermore recommend changing the Org name from ba-latex to dhsn-latex to conform with the current name.